### PR TITLE
Deploy private container to persistent data store

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -39,6 +39,7 @@ module "shared_services" {
   suffix                         = [local.unique_name_stub]
   log_retention_duration         = 30
   authorized_audit_client_ips    = [data.external.test_client_ip.result.ip]
+  authorized_persistent_data_client_ips = [data.external.test_client_ip.result.ip]
   authorized_audit_subnet_ids    = [azurerm_subnet.example_workload_subnet.id]
   authorized_security_client_ips = [data.external.test_client_ip.result.ip]
   authorized_security_subnet_ids = [azurerm_subnet.example_workload_subnet.id]

--- a/main.tf
+++ b/main.tf
@@ -154,6 +154,12 @@ module "persistent_data" {
   bypass_internal_network_rules        = true
 }
 
+resource "azurerm_storage_container" "private_container" {
+  name                  = "private-container"
+  storage_account_name  =  module.persistent_data.storage_account.name
+  container_access_type = "private"
+}
+
 #TODO: Check for key standard i.e key bit length and preferred crypto algorithm
 module "persistent_data_managed_encryption_key" {
   source                 = "git::https://github.com/Azure/terraform-azurerm-sec-storage-managed-encryption-key"


### PR DESCRIPTION
A private container named "private-container" is now deployed to the persistent_data storage account by default.

Encountered auth errors resulting from client IP not being added to the allowed IP ranges of the persistent storage account's firewall. The answer was to add this IP to the specific variable `authorized_persistent_data_client_ips`, so I've included this in the complete example.