### PR TITLE
Commented out the Azure Firewall

### DIFF
--- a/diagnostic_settings_submodule/virtual_network/main.tf
+++ b/diagnostic_settings_submodule/virtual_network/main.tf
@@ -116,7 +116,7 @@ resource "azurerm_monitor_diagnostic_setting" "secrets_nsg_diagnostic_setting" {
   }
 }
 
-resource "azurerm_monitor_diagnostic_setting" "firewall_diagnostic_setting" {
+/* resource "azurerm_monitor_diagnostic_setting" "firewall_diagnostic_setting" {
   name                       = "setByPolicy"
   target_resource_id         = var.shared_service_firewall.firewall.id
   storage_account_id         = var.shared_service_diag_storage.id
@@ -168,7 +168,7 @@ resource "azurerm_monitor_diagnostic_setting" "firewall_pip_diagnostic_setting" 
       enabled = true
     }
   }
-}
+} */
 
 
 resource "azurerm_network_watcher_flow_log" "network_flow_diagnostics" {

--- a/diagnostic_settings_submodule/virtual_network/variables.tf
+++ b/diagnostic_settings_submodule/virtual_network/variables.tf
@@ -22,9 +22,9 @@ variable "shared_service_secrets_nsg" {
   type = any
 }
 
-variable "shared_service_firewall" {
+/* variable "shared_service_firewall" {
   type = any
-}
+} */
 
 variable "shared_service_diag_storage" {
   type = any

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -43,7 +43,7 @@ module "shared_services" {
   authorized_audit_subnet_ids           = [azurerm_subnet.example_workload_subnet.id]
   authorized_security_client_ips        = [data.external.test_client_ip.result.ip]
   authorized_security_subnet_ids        = [azurerm_subnet.example_workload_subnet.id]
-  firewall_public_ip_sku                = "Standard"
+  #firewall_public_ip_sku                = "Standard"
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -10,13 +10,13 @@ provider "azuredevops" {
 }
 
 locals {
-  suffix                         = concat(["ss"], var.suffix)
-  resource_group_location        = var.resource_group_location
-  network_watcher_resource_group = "NetworkWatcherRG"
-  build_agent_subnet_id          = module.backend.build_subnet_id
-  authorized_audit_subnet_ids    = concat(var.authorized_audit_subnet_ids, [ local.build_agent_subnet_id ])
-  authorized_security_subnet_ids = concat(var.authorized_security_subnet_ids, [ local.build_agent_subnet_id ])
-  authorized_persistent_data_subnet_ids     = concat(var.authorized_persistent_data_subnet_ids, [ local.build_agent_subnet_id ])
+  suffix                                = concat(["ss"], var.suffix)
+  resource_group_location               = var.resource_group_location
+  network_watcher_resource_group        = "NetworkWatcherRG"
+  build_agent_subnet_id                 = module.backend.build_subnet_id
+  authorized_audit_subnet_ids           = concat(var.authorized_audit_subnet_ids, [local.build_agent_subnet_id])
+  authorized_security_subnet_ids        = concat(var.authorized_security_subnet_ids, [local.build_agent_subnet_id])
+  authorized_persistent_data_subnet_ids = concat(var.authorized_persistent_data_subnet_ids, [local.build_agent_subnet_id])
 }
 
 module "naming" {
@@ -40,7 +40,7 @@ module "virtual_network" {
   use_existing_resource_group = var.use_existing_resource_group
   resource_group_name         = var.resource_group_name
   resource_group_location     = local.resource_group_location
-  firewall_public_ip_sku      = var.firewall_public_ip_sku
+  #firewall_public_ip_sku      = var.firewall_public_ip_sku
 }
 
 module "virtual_network_diagnostic_settings" {
@@ -51,10 +51,10 @@ module "virtual_network_diagnostic_settings" {
   shared_service_data_nsg                 = module.virtual_network.data_subnet_network_security_group
   shared_service_audit_nsg                = module.virtual_network.audit_subnet_network_security_group
   shared_service_secrets_nsg              = module.virtual_network.secrets_subnet_network_security_group
-  shared_service_firewall                 = module.virtual_network.firewall
-  shared_service_diag_storage             = module.audit_diagnostics_package.storage_account
-  shared_service_diag_log_analytics       = module.audit_diagnostics_package.log_analytics_workspace
-  shared_service_log_retention_duration   = var.log_retention_duration
+  #shared_service_firewall                 = module.virtual_network.firewall
+  shared_service_diag_storage           = module.audit_diagnostics_package.storage_account
+  shared_service_diag_log_analytics     = module.audit_diagnostics_package.log_analytics_workspace
+  shared_service_log_retention_duration = var.log_retention_duration
 }
 
 module "virtual_networking_policy" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -34,9 +34,9 @@ output "net_virtual_network" {
   value = module.virtual_network.virtual_network
 }
 
-output "net_firewall_subnet" {
+/* output "net_firewall_subnet" {
   value = module.virtual_network.firewall_subnet
-}
+} */
 
 output "net_secrets_subnet" {
   value = module.virtual_network.secrets_subnet

--- a/shared_services_networking/examples/complete/main.tf
+++ b/shared_services_networking/examples/complete/main.tf
@@ -16,7 +16,7 @@ module "virtual_networking" {
   virtual_network_cidr        = "10.0.0.0/20"
   use_existing_resource_group = false
   resource_group_location     = "uksouth"
-  firewall_public_ip_sku      = "Standard"
-  suffix                      = [local.unique_name_stub]
+  #firewall_public_ip_sku      = "Standard"
+  suffix = [local.unique_name_stub]
 }
 

--- a/shared_services_networking/examples/complete/outputs.tf
+++ b/shared_services_networking/examples/complete/outputs.tf
@@ -2,9 +2,9 @@ output "resource_group" {
   value = module.virtual_networking.resource_group
 }
 
-output "firewall_subnet" {
+/* output "firewall_subnet" {
   value = module.virtual_networking.firewall_subnet
-}
+} */
 
 output "secrets_subnet" {
   value = module.virtual_networking.secrets_subnet
@@ -21,7 +21,7 @@ output "data_subnet" {
 output "virtual_network" {
   value = module.virtual_networking.virtual_network
   depends_on = [
-    module.virtual_networking.firewall_subnet,
+    #module.virtual_networking.firewall_subnet,
     module.virtual_networking.secrets_subnet,
     module.virtual_networking.audit_subnet,
     module.virtual_networking.data_subnet

--- a/shared_services_networking/examples/minimal/outputs.tf
+++ b/shared_services_networking/examples/minimal/outputs.tf
@@ -2,9 +2,9 @@ output "resource_group" {
   value = module.virtual_networking.resource_group
 }
 
-output "firewall_subnet" {
+/* output "firewall_subnet" {
   value = module.virtual_networking.firewall_subnet
-}
+} */
 
 output "secrets_subnet" {
   value = module.virtual_networking.secrets_subnet
@@ -21,7 +21,7 @@ output "data_subnet" {
 output "virtual_network" {
   value = module.virtual_networking.virtual_network
   depends_on = [
-    module.virtual_networking.firewall_subnet,
+    #module.virtual_networking.firewall_subnet,
     module.virtual_networking.secrets_subnet,
     module.virtual_networking.audit_subnet,
     module.virtual_networking.data_subnet

--- a/shared_services_networking/main.tf
+++ b/shared_services_networking/main.tf
@@ -26,10 +26,13 @@ module "virtual_network" {
   suffix               = local.suffix
 }
 
-module "firewall" {
+#NOTE: An Azure Firewall has an associated monthly cost irrespective of whether or not it is being actively used. Current usecase does not require the firewall
+# to be in place.  
+
+/* module "firewall" {
   source             = "git::https://github.com/Azure/terraform-azurerm-sec-firewall"
   virtual_network    = module.virtual_network.virtual_network
   firewall_subnet_id = module.virtual_network.firewall_subnet.id
   suffix             = local.suffix
   public_ip_sku      = var.firewall_public_ip_sku
-}
+} */

--- a/shared_services_networking/outputs.tf
+++ b/shared_services_networking/outputs.tf
@@ -6,13 +6,13 @@ output "virtual_network" {
   value = module.virtual_network.virtual_network
 }
 
-output "firewall" {
+/* output "firewall" {
   value = module.firewall
 }
 
 output "firewall_subnet" {
   value = module.virtual_network.firewall_subnet
-}
+} */
 
 output "secrets_subnet" {
   value = module.virtual_network.secrets_subnet

--- a/shared_services_networking/variables.tf
+++ b/shared_services_networking/variables.tf
@@ -29,11 +29,11 @@ variable "resource_group_location" {
   default     = ""
 }
 
-variable "firewall_public_ip_sku" {
+/* variable "firewall_public_ip_sku" {
   type        = string
   description = "The pricing and performance sku to create the Azure Firewalls public IP address to."
   default     = "Standard"
-}
+} */
 
 
 

--- a/shared_services_networking/virtual_network_sub_module/main.tf
+++ b/shared_services_networking/virtual_network_sub_module/main.tf
@@ -18,14 +18,6 @@ resource "azurerm_virtual_network" "virtual_network" {
   address_space       = [var.virtual_network_cidr]
 }
 
-resource "azurerm_subnet" "firewall_subnet" {
-  name                 = "AzureFirewallSubnet"
-  resource_group_name  = var.resource_group.name
-  virtual_network_name = azurerm_virtual_network.virtual_network.name
-  address_prefixes     = [cidrsubnet(var.virtual_network_cidr, 3, 0)]
-  service_endpoints    = ["Microsoft.Storage"]
-}
-
 ///////////////////////////////////
 // Secrets Subnet
 ///////////////////////////////////
@@ -39,7 +31,7 @@ resource "azurerm_subnet" "secrets_subnet" {
   name                                           = join(module.secrets_subnet_naming.subnet.dashes ? "-" : "", [module.secrets_subnet_naming.subnet.name, "secrets"])
   resource_group_name                            = var.resource_group.name
   virtual_network_name                           = azurerm_virtual_network.virtual_network.name
-  address_prefixes                               = [cidrsubnet(var.virtual_network_cidr, 3, 1)]
+  address_prefixes                               = [cidrsubnet(var.virtual_network_cidr, 3, 0)]
   service_endpoints                              = ["Microsoft.KeyVault", "Microsoft.Storage"]
   enforce_private_link_endpoint_network_policies = true
 }
@@ -68,7 +60,7 @@ resource "azurerm_subnet" "audit_subnet" {
   name                                           = join(module.audit_subnet_naming.subnet.dashes ? "-" : "", [module.audit_subnet_naming.subnet.name, "audit"])
   resource_group_name                            = var.resource_group.name
   virtual_network_name                           = azurerm_virtual_network.virtual_network.name
-  address_prefixes                               = [cidrsubnet(var.virtual_network_cidr, 3, 2)]
+  address_prefixes                               = [cidrsubnet(var.virtual_network_cidr, 3, 1)]
   service_endpoints                              = ["Microsoft.EventHub", "Microsoft.Storage"]
   enforce_private_link_endpoint_network_policies = true
 }
@@ -97,7 +89,7 @@ resource "azurerm_subnet" "data_subnet" {
   name                                           = join(module.data_subnet_naming.subnet.dashes ? "-" : "", [module.data_subnet_naming.subnet.name, "data"])
   resource_group_name                            = var.resource_group.name
   virtual_network_name                           = azurerm_virtual_network.virtual_network.name
-  address_prefixes                               = [cidrsubnet(var.virtual_network_cidr, 3, 3)]
+  address_prefixes                               = [cidrsubnet(var.virtual_network_cidr, 3, 2)]
   service_endpoints                              = ["Microsoft.Storage", "Microsoft.KeyVault", "Microsoft.AzureActiveDirectory"]
   enforce_private_link_endpoint_network_policies = true
 }
@@ -112,3 +104,15 @@ resource "azurerm_subnet_network_security_group_association" "data_nsg_asso" {
   subnet_id                 = azurerm_subnet.data_subnet.id
   network_security_group_id = azurerm_network_security_group.data_nsg.id
 }
+
+///////////////////////////////////
+// Firewall Subnet
+///////////////////////////////////
+
+/* resource "azurerm_subnet" "firewall_subnet" {
+  name                 = "AzureFirewallSubnet"
+  resource_group_name  = var.resource_group.name
+  virtual_network_name = azurerm_virtual_network.virtual_network.name
+  address_prefixes     = [cidrsubnet(var.virtual_network_cidr, 3, 3)]
+  service_endpoints    = ["Microsoft.Storage"]
+} */

--- a/shared_services_networking/virtual_network_sub_module/outputs.tf
+++ b/shared_services_networking/virtual_network_sub_module/outputs.tf
@@ -2,9 +2,9 @@ output "resource_group" {
   value = var.resource_group
 }
 
-output "firewall_subnet" {
+/* output "firewall_subnet" {
   value = azurerm_subnet.firewall_subnet
-}
+} */
 
 output "secrets_subnet" {
   value = azurerm_subnet.secrets_subnet
@@ -33,7 +33,7 @@ output "data_subnet_network_security_group" {
 output "virtual_network" {
   value = azurerm_virtual_network.virtual_network
   depends_on = [
-    azurerm_subnet.firewall_subnet,
+    #azurerm_subnet.firewall_subnet,
     azurerm_subnet.secrets_subnet,
     azurerm_subnet.audit_subnet,
     azurerm_subnet.data_subnet

--- a/variables.tf
+++ b/variables.tf
@@ -87,11 +87,11 @@ variable "authorized_security_subnet_ids" {
   default     = []
 }
 
-variable "firewall_public_ip_sku" {
+/* variable "firewall_public_ip_sku" {
   type        = string
   description = "The pricing and performance sku to create the Azure Firewalls public IP address to."
   default     = "Standard"
-}
+} */
 
 
 


### PR DESCRIPTION
In the instance in which we are aware of the az Firewall is not immediately used. This PR comments out the az Firewall to avoid the incuring of costs for a service that isnt being directly used currently. 